### PR TITLE
Update Standard Medical Deduction logic based on new info

### DIFF
--- a/features/il.feature
+++ b/features/il.feature
@@ -6,11 +6,6 @@
 # Some calculations result in small differences, which may be due
 # to rounding differences or slightly different data sets being used.
 
-# A few surprising results from the Illinois calculator:
-# * Standard deduction listed as $160 instead of $167.
-# * Family of 3 with an elderly or disabled household member, medical expenses
-#   of $135 lists Medical Deduction as $165 instead of $100.
-
 Feature: Illinois scenarios, no EA waiver
 
   Background:
@@ -142,7 +137,7 @@ Feature: Illinois scenarios, no EA waiver
       Then we find the family is likely eligible
       And we find the estimated benefit is $341 per month
 
-  Scenario: Medical expenses of $36 increase deduction by $165, benefit by ~$50
+  Scenario: Medical expenses of $36 increase deduction by $200, benefit by $60
     Given a 3-person household
     And the household does include an elderly or disabled member
     And the household has earned income of $400 monthly
@@ -150,9 +145,9 @@ Feature: Illinois scenarios, no EA waiver
     And the household has medical expenses for elderly or disabled members of $36 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
-      And we find the estimated benefit is $390 per month
+      And we find the estimated benefit is $401 per month
 
-  Scenario: Medical expenses of $135 increase deduction by $165, benefit by ~$50
+  Scenario: Medical expenses of $135 increase deduction by $200, benefit by $60
     Given a 3-person household
     And the household does include an elderly or disabled member
     And the household has earned income of $400 monthly
@@ -160,27 +155,17 @@ Feature: Illinois scenarios, no EA waiver
     And the household has medical expenses for elderly or disabled members of $135 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
-      And we find the estimated benefit is $390 per month
-
-  Scenario: Medical expenses of $210 increase deduction by $175, benefit by $53
-    Given a 3-person household
-    And the household does include an elderly or disabled member
-    And the household has earned income of $400 monthly
-    And the household has other income of $400 monthly
-    And the household has medical expenses for elderly or disabled members of $210 monthly
-    When we run the benefit estimator...
-      Then we find the family is likely eligible
-      And we find the estimated benefit is $393 per month
-
-  Scenario: Medical expenses of $235 increase deduction by $200, benefit by $60
-    Given a 3-person household
-    And the household does include an elderly or disabled member
-    And the household has earned income of $400 monthly
-    And the household has other income of $400 monthly
-    And the household has medical expenses for elderly or disabled members of $235 monthly
-    When we run the benefit estimator...
-      Then we find the family is likely eligible
       And we find the estimated benefit is $401 per month
+
+  Scenario: Medical expenses of $300 increase deduction by $300, benefit by $90
+    Given a 3-person household
+    And the household does include an elderly or disabled member
+    And the household has earned income of $400 monthly
+    And the household has other income of $400 monthly
+    And the household has medical expenses for elderly or disabled members of $300 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      And we find the estimated benefit is $431 per month
 
   Scenario: Medical expenses do not affect benefit if household does not include an elderly or disabled member
     Given a 3-person household

--- a/features/va.feature
+++ b/features/va.feature
@@ -119,3 +119,42 @@ Feature: Virginia scenarios, no EA waiver
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $124 per month
+
+
+  # MEDICAL STANDARD DEDUCTION #
+
+  Scenario: Household with medical expenses below $35 threshold
+    Given a 1-person household
+    And the household has other income of $700 monthly
+    And the household does include an elderly or disabled member
+    And the household has medical expenses for elderly or disabled members of $34 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $34 per month
+
+  Scenario: Household with medical expenses above $35 threshold
+    Given a 1-person household
+    And the household has other income of $700 monthly
+    And the household does include an elderly or disabled member
+    And the household has medical expenses for elderly or disabled members of $36 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $94 per month
+
+  Scenario: Household with medical expenses below $235 threshold
+    Given a 1-person household
+    And the household has other income of $700 monthly
+    And the household does include an elderly or disabled member
+    And the household has medical expenses for elderly or disabled members of $234 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $94 per month
+
+  Scenario: Household with medical expenses above $235 threshold
+    Given a 1-person household
+    And the household has other income of $700 monthly
+    And the household does include an elderly or disabled member
+    And the household has medical expenses for elderly or disabled members of $300 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $124 per month

--- a/src/deductions/medical_expenses_deduction.js
+++ b/src/deductions/medical_expenses_deduction.js
@@ -7,6 +7,7 @@ export class MedicalExpensesDeduction {
         this.medical_expenses_for_elderly_or_disabled = inputs.medical_expenses_for_elderly_or_disabled;
         this.standard_medical_deduction = inputs.standard_medical_deduction;
         this.standard_medical_deduction_amount = inputs.standard_medical_deduction_amount;
+        this.standard_medical_deduction_ceiling = inputs.standard_medical_deduction_ceiling;
     }
 
     calculate() {
@@ -67,15 +68,15 @@ export class MedicalExpensesDeduction {
         }
 
         // State that uses a Standard Medical Deduction
-        const expenses_above_standard = (
-            this.medical_expenses_for_elderly_or_disabled > (this.standard_medical_deduction_amount + 35)
+        const expenses_above_ceiling = (
+            this.medical_expenses_for_elderly_or_disabled > this.standard_medical_deduction_ceiling
         );
 
-        if (expenses_above_standard) {
-            const medical_expenses_deduction = this.medical_expenses_for_elderly_or_disabled - 35;
+        if (expenses_above_ceiling) {
+            const medical_expenses_deduction = this.medical_expenses_for_elderly_or_disabled;
 
             explanation.push(
-                `Medical expenses are greater than the Standard Medical Deduction amount of $${this.standard_medical_deduction_amount}. In this case, the full medical expense amount less $35 can be deducted, which comes to $${medical_expenses_deduction}. `
+                `Medical expenses are greater than the Standard Medical Deduction maximum amount of $${this.standard_medical_deduction_ceiling}. In this case, the full medical expense amount can be deducted, which comes to $${medical_expenses_deduction}. `
             );
 
             return {

--- a/src/income/net_income.js
+++ b/src/income/net_income.js
@@ -16,6 +16,7 @@ export class NetIncome {
         this.medical_expenses_for_elderly_or_disabled = inputs.medical_expenses_for_elderly_or_disabled;
         this.standard_medical_deduction = inputs.standard_medical_deduction;
         this.standard_medical_deduction_amount = inputs.standard_medical_deduction_amount;
+        this.standard_medical_deduction_ceiling = inputs.standard_medical_deduction_ceiling;
         this.rent_or_mortgage = inputs.rent_or_mortgage;
         this.homeowners_insurance_and_taxes = inputs.homeowners_insurance_and_taxes;
         this.utility_costs = inputs.utility_costs;
@@ -67,6 +68,7 @@ export class NetIncome {
             'medical_expenses_for_elderly_or_disabled': this.medical_expenses_for_elderly_or_disabled,
             'standard_medical_deduction': this.standard_medical_deduction,
             'standard_medical_deduction_amount': this.standard_medical_deduction_amount,
+            'standard_medical_deduction_ceiling': this.standard_medical_deduction_ceiling,
         }).calculate();
 
         const child_support_payments_deduction = new ChildSupportPaymentsDeduction({

--- a/src/program_data/state_options.js
+++ b/src/program_data/state_options.js
@@ -62,7 +62,8 @@ export const STATE_OPTIONS /*: StateOptions */ = {
             'resource_limit_elderly_or_disabled_income_twice_fpl': 3500,
             'resource_limit_non_elderly_or_disabled': null,
             'standard_medical_deduction': true,
-            'standard_medical_deduction_amount': 165,
+            'standard_medical_deduction_amount': 200,
+            'standard_medical_deduction_ceiling': 200,
             'standard_utility_allowances': {
                 'BASIC_LIMITED_ALLOWANCE': 328,
                 'HEATING_AND_COOLING': 478,
@@ -159,7 +160,8 @@ export const STATE_OPTIONS /*: StateOptions */ = {
             'child_support_payments_treatment': 'EXCLUDE', // This matches materials provided by VPLC and VA DSS but not the latest USDA State Options Report
             'mandatory_standard_utility_allowances': false,
             'standard_medical_deduction': true,
-            'standard_medical_deduction_amount': 140,
+            'standard_medical_deduction_amount': 200,
+            'standard_medical_deduction_ceiling': 235,
             'use_emergency_allotment': true,
             'uses_bbce': false,
             'website': 'https://commonhelp.virginia.gov/'

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -63,6 +63,7 @@ export class SnapEstimate {
     net_monthly_income_limit: number;
     standard_medical_deduction: boolean;
     standard_medical_deduction_amount: number;
+    standard_medical_deduction_ceiling: number;
     standard_utility_allowances: Object;
     mandatory_standard_utility_allowances: boolean;
     state_website: string;
@@ -119,6 +120,7 @@ export class SnapEstimate {
         this.child_support_payments_treatment = state_options['child_support_payments_treatment'];
         this.standard_medical_deduction = state_options['standard_medical_deduction'];
         this.standard_medical_deduction_amount = state_options['standard_medical_deduction_amount'];
+        this.standard_medical_deduction_ceiling = state_options['standard_medical_deduction_ceiling'];
         this.mandatory_standard_utility_allowances = state_options['mandatory_standard_utility_allowances'];
         this.standard_utility_allowances = state_options['standard_utility_allowances'];
         this.state_website = state_options['website'];
@@ -226,6 +228,7 @@ export class SnapEstimate {
             'medical_expenses_for_elderly_or_disabled': this.medical_expenses_for_elderly_or_disabled,
             'standard_medical_deduction': this.standard_medical_deduction,
             'standard_medical_deduction_amount': this.standard_medical_deduction_amount,
+            'standard_medical_deduction_ceiling': this.standard_medical_deduction_ceiling,
             'rent_or_mortgage': this.rent_or_mortgage,
             'homeowners_insurance_and_taxes': this.homeowners_insurance_and_taxes,
             'utility_costs': this.utility_costs,


### PR DESCRIPTION
# Notes 

+ Separate out standard medical deduction amount amount vs. ceiling (limit beyond which the actual medical expenses are used rather than the standard)
+ VA and IL seem to treat these differently: in IL, the ceiling is the same as the standard medical deduction amount, whereas in VA the ceiling equals standard medical deduction amount + $35

# References 

+ IL: https://www.dhs.state.il.us/page.aspx?Item=16142#:~:text=The%20Standard%20Medical%20Deduction%20for,%24200.
+ VA: "Manual SNAP Worksheet rev 05-2020" provided by VPLC