### PR TITLE
Add unit tests for parsing number inputs sent in as decimals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,10 @@
 version: 2.1
-orbs:
-  node: circleci/node@3.0.0
 jobs:
-  build-and-test:
-    executor:
-      name: node/default
+  build:
+    docker:
+      - image: circleci/node:12
     steps:
       - checkout
-      - node/install:
-          node-version: 12.18.0
       - run:
           name: Print node version
           command: node --version
@@ -27,7 +23,3 @@ jobs:
       - run:
           name: Linter
           command: npm run lint
-workflows:
-    build-and-test:
-      jobs:
-        - build-and-test

--- a/test/parse_inputs_test.js
+++ b/test/parse_inputs_test.js
@@ -47,6 +47,34 @@ describe('ParseInputs', () => {
         });
     });
 
+    it('parses decimal values into integer dollar amounts', () => {
+        const inputs = {
+            'state_or_territory': 'IL',
+            'monthly_job_income': '101.90',
+            'monthly_non_job_income': '101.10',
+            'household_size': '1',
+            'household_includes_elderly_or_disabled': 'false',
+            'resources': '1001.50'
+        };
+
+        const parser = new ParseInputs(inputs);
+
+        assert.equal(parser.inputs_valid(), true);
+        assert.deepEqual(parser.inputs, {
+            'court_ordered_child_support_payments': 0,
+            'dependent_care_costs': 0,
+            'homeowners_insurance_and_taxes': 0,
+            'household_includes_elderly_or_disabled': false,
+            'household_size': 1,
+            'medical_expenses_for_elderly_or_disabled': 0,
+            'monthly_job_income': 101,
+            'monthly_non_job_income': 101,
+            'rent_or_mortgage': 0,
+            'resources': 1001,
+            'state_or_territory': 'IL',
+            'utility_costs': 0,
+        });
+    });
 
     it('should parse string `true` to a boolean for a boolean field', () => {
         const inputs = {

--- a/test/parse_inputs_test.js
+++ b/test/parse_inputs_test.js
@@ -47,7 +47,7 @@ describe('ParseInputs', () => {
         });
     });
 
-    it('parses decimal values into integer dollar amounts', () => {
+    it('parses decimal values into integer dollar amounts (for required integers)', () => {
         const inputs = {
             'state_or_territory': 'IL',
             'monthly_job_income': '101.90',
@@ -67,6 +67,37 @@ describe('ParseInputs', () => {
             'household_includes_elderly_or_disabled': false,
             'household_size': 1,
             'medical_expenses_for_elderly_or_disabled': 0,
+            'monthly_job_income': 101,
+            'monthly_non_job_income': 101,
+            'rent_or_mortgage': 0,
+            'resources': 1001,
+            'state_or_territory': 'IL',
+            'utility_costs': 0,
+        });
+    });
+
+
+    it('parses decimal values into integer dollar amounts (for optional integers)', () => {
+        const inputs = {
+            'state_or_territory': 'IL',
+            'monthly_job_income': '101.90',
+            'monthly_non_job_income': '101.10',
+            'household_size': '1',
+            'household_includes_elderly_or_disabled': 'false',
+            'resources': '1001.50',
+            'medical_expenses_for_elderly_or_disabled': '108.80'
+        };
+
+        const parser = new ParseInputs(inputs);
+
+        assert.equal(parser.inputs_valid(), true);
+        assert.deepEqual(parser.inputs, {
+            'court_ordered_child_support_payments': 0,
+            'dependent_care_costs': 0,
+            'homeowners_insurance_and_taxes': 0,
+            'household_includes_elderly_or_disabled': false,
+            'household_size': 1,
+            'medical_expenses_for_elderly_or_disabled': 108,
             'monthly_job_income': 101,
             'monthly_non_job_income': 101,
             'rent_or_mortgage': 0,


### PR DESCRIPTION
# Notes 

+ Prescreener prototype allows users to send currency amounts as a decimal (cents); add JS API tests to surface how the API handles decimal inputs (rounds down to the nearest integer) 
+ Switch to faster CircleCI setup (match https://github.com/18F/snap-js-prescreener-prototypes)