### PR TITLE
v0.0.2: Update emergency allotment API; add "next steps" state data for VA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
           command: npm run lint
       - run:
           name: Scan dependencies
-          command: npm audit
+          command: npm audit --audit-level=moderate

--- a/features/step_definitions/file_steps.js
+++ b/features/step_definitions/file_steps.js
@@ -103,15 +103,15 @@ When('we run the benefit estimator...', function () {
 
   this.estimated_benefit = result.estimated_benefit;
   this.estimated_eligibility = result.estimated_eligibility;
-  this.estimated_benefit_start_of_month = result.estimated_benefit_start_of_month;
+  this.emergency_allotment_estimated_benefit = result.emergency_allotment_estimated_benefit;
 });
 
 Then('we find the estimated benefit is ${int} per month', function (estimated_benefit) {
   assert.equal(this.estimated_benefit, estimated_benefit);
 });
 
-Then('we find the estimated benefit at the start of the month is ${int}', function (estimated_benefit_start_of_month) {
-  assert.equal(this.estimated_benefit_start_of_month, estimated_benefit_start_of_month);
+Then('we find the estimated benefit including emergency allotment is ${int}', function (emergency_allotment_estimated_benefit) {
+  assert.equal(this.emergency_allotment_estimated_benefit, emergency_allotment_estimated_benefit);
 });
 
 Then('we find the family is likely {word}', function (estimated_eligibility) {

--- a/features/step_definitions/file_steps.js
+++ b/features/step_definitions/file_steps.js
@@ -101,13 +101,13 @@ When('we run the benefit estimator...', function () {
 
   const result = snap_estimator.calculate();
 
-  this.estimated_benefit = result.estimated_benefit;
+  this.estimated_monthly_benefit = result.estimated_monthly_benefit;
   this.estimated_eligibility = result.estimated_eligibility;
   this.emergency_allotment_estimated_benefit = result.emergency_allotment_estimated_benefit;
 });
 
-Then('we find the estimated benefit is ${int} per month', function (estimated_benefit) {
-  assert.equal(this.estimated_benefit, estimated_benefit);
+Then('we find the estimated benefit is ${int} per month', function (estimated_monthly_benefit) {
+  assert.equal(this.estimated_monthly_benefit, estimated_monthly_benefit);
 });
 
 Then('we find the estimated benefit including emergency allotment is ${int}', function (emergency_allotment_estimated_benefit) {

--- a/features/va.feature
+++ b/features/va.feature
@@ -69,8 +69,8 @@ Feature: Virginia scenarios, no EA waiver
     And an emergency allotment waiver
     When we run the benefit estimator...
       Then we find the family is likely eligible
-      And we find the estimated benefit is $194 per month
-      And we find the estimated benefit at the start of the month is $34
+      And we find the estimated benefit is $34 per month
+      And we find the estimated benefit including emergency allotment is $194
 
 
   # ASSET TEST #

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-js-rules",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A SNAP eligibility calculator in JavaScript",
   "private": "true",
   "dependencies": {},

--- a/src/amount/benefit_amount_estimate.js
+++ b/src/amount/benefit_amount_estimate.js
@@ -105,8 +105,8 @@ export class BenefitAmountEstimate {
         return {
             'name': 'Benefit Amount',
             'sort_order': 5,
-            'emergency_allotment_total': max_allotment,
             'result': estimated_benefit,
+            'emergency_allotment_estimated_benefit': max_allotment,
             'explanation': explanation,
         };
     }

--- a/src/amount/benefit_amount_estimate.js
+++ b/src/amount/benefit_amount_estimate.js
@@ -105,8 +105,8 @@ export class BenefitAmountEstimate {
         return {
             'name': 'Benefit Amount',
             'sort_order': 5,
-            'result_start_of_month': estimated_benefit, // How much a household could expect to receive at the beginning of each month.
-            'result': max_allotment, // How much a household could expect to receive in total in a month.
+            'emergency_allotment_total': max_allotment,
+            'result': estimated_benefit,
             'explanation': explanation,
         };
     }

--- a/src/input_data/parse_input_data.js
+++ b/src/input_data/parse_input_data.js
@@ -70,11 +70,15 @@ export class ParseInputs {
     }
 
     handle_required_integer_input(input_key) {
-        const input_value = this.inputs[input_key];
+        let input_value = this.inputs[input_key];
 
         if (input_value === null || input_value === undefined) {
             this.errors.push(`Missing required input: ${input_key}`);
             return false;
+        }
+
+        if (typeof input_value === 'string') {
+            input_value = input_value.replace(/,/g, '');
         }
 
         const try_parse_int = parseInt(input_value);

--- a/src/program_data/state_options.js
+++ b/src/program_data/state_options.js
@@ -164,7 +164,17 @@ export const STATE_OPTIONS /*: StateOptions */ = {
             'standard_medical_deduction_ceiling': 235,
             'use_emergency_allotment': true,
             'uses_bbce': false,
-            'website': 'https://commonhelp.virginia.gov/'
+            'website': 'https://commonhelp.virginia.gov/',
+            'next_steps': [
+                {
+                    'url': 'https://commonhelp.virginia.gov/',
+                    'name': 'Apply online using CommonHelp.',
+                },
+                {
+                    'url': 'https://www.dss.virginia.gov/localagency/index.cgi',
+                    'name': 'Apply at a local department near you.',
+                }
+            ]
         }
     },
     'VT': {

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -164,7 +164,7 @@ export class SnapEstimate {
 
         const benefit_amount_calculation = benefit_amount_estimate.calculate();
         this.estimated_monthly_benefit = benefit_amount_calculation.result;
-        this.emergency_allotment_estimated_benefit = benefit_amount_calculation.emergency_allotment_total;
+        this.emergency_allotment_estimated_benefit = benefit_amount_calculation.emergency_allotment_estimated_benefit;
 
         const eligibility_factors/*: Array<Array<string>> */ = [
             gross_income_calculation,

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -75,9 +75,9 @@ export class SnapEstimate {
     net_income: number;
 
     // Outputs
-    estimated_benefit: number;
-    emergency_allotment_estimated_benefit: ?number;
     estimated_eligibility: boolean;
+    estimated_monthly_benefit: number;
+    emergency_allotment_estimated_benefit: ?number;
     */
 
     constructor(inputs /*: SnapEstimateInputs */) {
@@ -163,7 +163,7 @@ export class SnapEstimate {
         });
 
         const benefit_amount_calculation = benefit_amount_estimate.calculate();
-        this.estimated_benefit = benefit_amount_calculation.result;
+        this.estimated_monthly_benefit = benefit_amount_calculation.result;
         this.emergency_allotment_estimated_benefit = benefit_amount_calculation.emergency_allotment_total;
 
         const eligibility_factors/*: Array<Array<string>> */ = [
@@ -174,7 +174,7 @@ export class SnapEstimate {
 
         return {
             'status': 'OK',
-            'estimated_benefit': this.estimated_benefit,
+            'estimated_monthly_benefit': this.estimated_monthly_benefit,
             'emergency_allotment_estimated_benefit': this.emergency_allotment_estimated_benefit, // If emergency allotments are in effect, a household may receive a higher benefit total. This value may be null if emergency allotments are not in effect.
             'estimated_eligibility': this.estimated_eligibility,
             'eligibility_factors': eligibility_factors,

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -76,7 +76,7 @@ export class SnapEstimate {
 
     // Outputs
     estimated_benefit: number;
-    estimated_benefit_start_of_month: ?number;
+    emergency_allotment_estimated_benefit: ?number;
     estimated_eligibility: boolean;
     */
 
@@ -164,7 +164,7 @@ export class SnapEstimate {
 
         const benefit_amount_calculation = benefit_amount_estimate.calculate();
         this.estimated_benefit = benefit_amount_calculation.result;
-        this.estimated_benefit_start_of_month = benefit_amount_calculation.result_start_of_month;
+        this.emergency_allotment_estimated_benefit = benefit_amount_calculation.emergency_allotment_total;
 
         const eligibility_factors/*: Array<Array<string>> */ = [
             gross_income_calculation,
@@ -175,7 +175,7 @@ export class SnapEstimate {
         return {
             'status': 'OK',
             'estimated_benefit': this.estimated_benefit,
-            'estimated_benefit_start_of_month': this.estimated_benefit_start_of_month, // If emergency allotments are in effect, a household may receive their regular benefit at the start of the month and the remainder later in the month. This value may be null.
+            'emergency_allotment_estimated_benefit': this.emergency_allotment_estimated_benefit, // If emergency allotments are in effect, a household may receive a higher benefit total. This value may be null if emergency allotments are not in effect.
             'estimated_eligibility': this.estimated_eligibility,
             'eligibility_factors': eligibility_factors,
             'state_website': this.state_website,

--- a/test/parse_inputs_test.js
+++ b/test/parse_inputs_test.js
@@ -76,7 +76,6 @@ describe('ParseInputs', () => {
         });
     });
 
-
     it('parses decimal values into integer dollar amounts (for optional integers)', () => {
         const inputs = {
             'state_or_territory': 'IL',
@@ -100,6 +99,36 @@ describe('ParseInputs', () => {
             'medical_expenses_for_elderly_or_disabled': 108,
             'monthly_job_income': 101,
             'monthly_non_job_income': 101,
+            'rent_or_mortgage': 0,
+            'resources': 1001,
+            'state_or_territory': 'IL',
+            'utility_costs': 0,
+        });
+    });
+
+    it('should parse commas in number correctly', () => {
+        const inputs = {
+            'state_or_territory': 'IL',
+            'monthly_job_income': '1,000',
+            'monthly_non_job_income': '1,000',
+            'household_size': '1',
+            'household_includes_elderly_or_disabled': 'false',
+            'resources': '1001.50',
+            'medical_expenses_for_elderly_or_disabled': '108.80'
+        };
+
+        const parser = new ParseInputs(inputs);
+
+        assert.equal(parser.inputs_valid(), true);
+        assert.deepEqual(parser.inputs, {
+            'court_ordered_child_support_payments': 0,
+            'dependent_care_costs': 0,
+            'homeowners_insurance_and_taxes': 0,
+            'household_includes_elderly_or_disabled': false,
+            'household_size': 1,
+            'medical_expenses_for_elderly_or_disabled': 108,
+            'monthly_job_income': 1000,
+            'monthly_non_job_income': 1000,
             'rent_or_mortgage': 0,
             'resources': 1001,
             'state_or_territory': 'IL',
@@ -206,8 +235,5 @@ describe('ParseInputs', () => {
             'Unknown standard utility allowance: 7'
         ]);
     });
-
-
-
 });
 


### PR DESCRIPTION
# API output changes (0.0.2)

### Outputs

+ `estimated_benefit` => `estimated_monthly_benefit`: More precise variable name; less room for misinterpretation. 
+ Use `emergency_allotment_estimated_benefit` for total benefit amount under EA instead of returning an `estimated_benefit_start_of_month`, with the remainder being the emergency allotment. 
  + This feels like a clearer way to approach EAs, since whether the extra benefit arrives later in the month or bundled at the beginning of the month is an implementation detail. 
+ Add a `next_steps` array to support multiple possible next steps per state. 

### Improvements 

+ Strip commas out of user-entered numbers that are sent down as `string`s; e.g. `"6,000"` => `6000`

# Corresponding pre-screener branch 

https://github.com/18F/snap-js-prescreener-prototypes/pull/29