### PR TITLE
Virginia Standard Utility Allowance update

### DIFF
--- a/features/step_definitions/file_steps.js
+++ b/features/step_definitions/file_steps.js
@@ -78,10 +78,6 @@ Given('the household is not billed separately for any utilities', function () {
     this.utility_allowance = 'NONE';
 });
 
-Given('the household has utility costs of ${int} monthly', function (utility_costs) {
-  this.utility_costs = utility_costs;
-});
-
 When('we run the benefit estimator...', function () {
   const snap_estimator = new SnapEstimateEntrypoint({
     'household_includes_elderly_or_disabled': this.household_includes_elderly_or_disabled,

--- a/features/va.feature
+++ b/features/va.feature
@@ -158,3 +158,50 @@ Feature: Virginia scenarios, no EA waiver
     When we run the benefit estimator...
       Then we find the family is likely eligible
       Then we find the estimated benefit is $124 per month
+
+
+  # STANDARD UTILITY ALLOWANCE #
+
+  Scenario:
+    Given a 1-person household
+    And the household has other income of $1200 monthly
+    And the household has rent or mortgage costs of $1200 monthly
+    And the household pays for AC or heat, or otherwise qualifies for AC-heat utility allowance
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $55 per month
+
+  # Household already receiving the max excess shelter deduction, so no
+  # increase in estimated benefit amount after adding utility allowance:
+  Scenario:
+    Given a 1-person household
+    And the household has other income of $1200 monthly
+    And the household has rent or mortgage costs of $1200 monthly
+    And the household pays for AC or heat, or otherwise qualifies for AC-heat utility allowance
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $55 per month
+
+  # Household with elderly or disabled household member (no limit to shelter deduction)
+  # that does not have a heating/cooling utility allowance:
+  Scenario:
+    Given a 1-person household
+    And the household does include an elderly or disabled member
+    And the household has other income of $1200 monthly
+    And the household has rent or mortgage costs of $1200 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $89 per month
+
+  # Household with elderly or disabled household member (no limit to shelter deduction)
+  # that has a heating/cooling utility allowance, benefit increases in proportion
+  # to the VA standard utility allowance:
+  Scenario:
+    Given a 1-person household
+    And the household does include an elderly or disabled member
+    And the household has other income of $1200 monthly
+    And the household has rent or mortgage costs of $1200 monthly
+    And the household pays for AC or heat, or otherwise qualifies for AC-heat utility allowance
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $180 per month

--- a/features/va.feature
+++ b/features/va.feature
@@ -205,3 +205,14 @@ Feature: Virginia scenarios, no EA waiver
     When we run the benefit estimator...
       Then we find the family is likely eligible
       Then we find the estimated benefit is $180 per month
+
+  # Larger household (four or more people) gets a different SUA amount:
+  Scenario:
+    Given a 5-person household
+    And the household does include an elderly or disabled member
+    And the household has other income of $1200 monthly
+    And the household has rent or mortgage costs of $1200 monthly
+    And the household pays for AC or heat, or otherwise qualifies for AC-heat utility allowance
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      Then we find the estimated benefit is $768 per month

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-js-rules",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A SNAP eligibility calculator in JavaScript",
   "private": "true",
   "dependencies": {},

--- a/src/deductions/shelter_deduction.js
+++ b/src/deductions/shelter_deduction.js
@@ -149,14 +149,14 @@ export class ShelterDeduction {
 
                     return {
                         'result': result,
-                        'explanation': `Virginia has a standard utility allowance of ${result} for households with four or more household members.`,
+                        'explanation': `Virginia has a standard utility allowance of $${result} for households with four or more household members.`,
                     };
                 } else {
                     let result = heating_cooling_allowances['below_four'];
 
                     return {
                         'result': result,
-                        'explanation': `Virginia has a standard utility allowance of ${result} for households with less than four household members.`,
+                        'explanation': `Virginia has a standard utility allowance of $${result} for households with less than four household members.`,
                     };
                 }
             }

--- a/src/deductions/shelter_deduction.js
+++ b/src/deductions/shelter_deduction.js
@@ -8,7 +8,6 @@ export class ShelterDeduction {
         this.household_includes_elderly_or_disabled = inputs.household_includes_elderly_or_disabled;
         this.state_or_territory = inputs.state_or_territory;
         this.household_size = inputs.household_size;
-        this.utility_costs = inputs.utility_costs;
         this.utility_allowance = inputs.utility_allowance;
         this.standard_utility_allowances = inputs.standard_utility_allowances;
     }

--- a/src/deductions/shelter_deduction.js
+++ b/src/deductions/shelter_deduction.js
@@ -119,14 +119,6 @@ export class ShelterDeduction {
     }
 
     calculate_utility_costs() {
-        // State without Standard Utility Allowances
-        if (!this.mandatory_standard_utility_allowances) {
-            return {
-                'result': this.utility_costs,
-                'explanation': `In this case, the household has utility costs of $${this.utility_costs}, so total shelter plus utilities costs come to $${this.base_shelter_costs + this.utility_costs}.`
-            };
-        }
-
         // State with Standard Utility Allowances, no utility allowance claimed
         if (this.utility_allowance === null || this.utility_allowance === 'NONE') {
             // In this case the client has either:
@@ -143,6 +135,38 @@ export class ShelterDeduction {
                     'In this case there is no deduction for utilities, likely ' +
                     'because the household is not billed separately for utilities.'
                 )
+            };
+        }
+
+        // VA is one of a few states that adjust standard utility allowances
+        // based on household size
+        if (this.state_or_territory === 'VA') {
+            if (this.utility_allowance === 'HEATING_AND_COOLING') {
+                const heating_cooling_allowances = this.standard_utility_allowances['HEATING_AND_COOLING'];
+
+                if (this.household_size >= 4) {
+                    let result = heating_cooling_allowances['four_or_more'];
+
+                    return {
+                        'result': result,
+                        'explanation': `Virginia has a standard utility allowance of ${result} for households with four or more household members.`,
+                    };
+                } else {
+                    let result = heating_cooling_allowances['below_four'];
+
+                    return {
+                        'result': result,
+                        'explanation': `Virginia has a standard utility allowance of ${result} for households with less than four household members.`,
+                    };
+                }
+            }
+        }
+
+        // State without Standard Utility Allowances
+        if (!this.mandatory_standard_utility_allowances) {
+            return {
+                'result': this.utility_costs,
+                'explanation': `In this case, the household has utility costs of $${this.utility_costs}, so total shelter plus utilities costs come to $${this.base_shelter_costs + this.utility_costs}.`
             };
         }
 

--- a/src/deductions/shelter_deduction.js
+++ b/src/deductions/shelter_deduction.js
@@ -10,7 +10,6 @@ export class ShelterDeduction {
         this.household_size = inputs.household_size;
         this.utility_costs = inputs.utility_costs;
         this.utility_allowance = inputs.utility_allowance;
-        this.mandatory_standard_utility_allowances = inputs.mandatory_standard_utility_allowances;
         this.standard_utility_allowances = inputs.standard_utility_allowances;
     }
 
@@ -160,14 +159,6 @@ export class ShelterDeduction {
                     };
                 }
             }
-        }
-
-        // State without Standard Utility Allowances
-        if (!this.mandatory_standard_utility_allowances) {
-            return {
-                'result': this.utility_costs,
-                'explanation': `In this case, the household has utility costs of $${this.utility_costs}, so total shelter plus utilities costs come to $${this.base_shelter_costs + this.utility_costs}.`
-            };
         }
 
         // State with Standard Utility Allowances, utility allowance claimed

--- a/src/income/net_income.js
+++ b/src/income/net_income.js
@@ -21,7 +21,6 @@ export class NetIncome {
         this.homeowners_insurance_and_taxes = inputs.homeowners_insurance_and_taxes;
         this.utility_costs = inputs.utility_costs;
         this.utility_allowance = inputs.utility_allowance;
-        this.mandatory_standard_utility_allowances = inputs.mandatory_standard_utility_allowances;
         this.standard_utility_allowances = inputs.standard_utility_allowances;
         this.child_support_payments_treatment = inputs.child_support_payments_treatment;
         this.court_ordered_child_support_payments = inputs.court_ordered_child_support_payments;
@@ -108,7 +107,6 @@ export class NetIncome {
             'homeowners_insurance_and_taxes': this.homeowners_insurance_and_taxes,
             'utility_costs': this.utility_costs,
             'utility_allowance': this.utility_allowance,
-            'mandatory_standard_utility_allowances': this.mandatory_standard_utility_allowances,
             'standard_utility_allowances': this.standard_utility_allowances,
         }).calculate();
 

--- a/src/income/net_income.js
+++ b/src/income/net_income.js
@@ -19,7 +19,6 @@ export class NetIncome {
         this.standard_medical_deduction_ceiling = inputs.standard_medical_deduction_ceiling;
         this.rent_or_mortgage = inputs.rent_or_mortgage;
         this.homeowners_insurance_and_taxes = inputs.homeowners_insurance_and_taxes;
-        this.utility_costs = inputs.utility_costs;
         this.utility_allowance = inputs.utility_allowance;
         this.standard_utility_allowances = inputs.standard_utility_allowances;
         this.child_support_payments_treatment = inputs.child_support_payments_treatment;
@@ -105,7 +104,6 @@ export class NetIncome {
             'household_includes_elderly_or_disabled': this.household_includes_elderly_or_disabled,
             'rent_or_mortgage': this.rent_or_mortgage,
             'homeowners_insurance_and_taxes': this.homeowners_insurance_and_taxes,
-            'utility_costs': this.utility_costs,
             'utility_allowance': this.utility_allowance,
             'standard_utility_allowances': this.standard_utility_allowances,
         }).calculate();

--- a/src/input_data/parse_input_data.js
+++ b/src/input_data/parse_input_data.js
@@ -131,10 +131,10 @@ export class ParseInputs {
 
         const input_value = this.inputs[input_key];
 
-        // Convert null, undefined, '', NaN values to null:
+        // Convert null, undefined, '', NaN values to 'NONE':
         // https://developer.mozilla.org/en-US/docs/Glossary/Falsy
         if (!input_value) {
-            this.inputs[input_key] = null;
+            this.inputs[input_key] = 'NONE';
             return true;
         }
 

--- a/src/input_data/parse_input_data.js
+++ b/src/input_data/parse_input_data.js
@@ -131,9 +131,9 @@ export class ParseInputs {
 
         const input_value = this.inputs[input_key];
 
-        // Utility allowance can be blank or '', if the household is in a state
-        // that uses raw utility costs instead of standard utility allowances.
-        if (input_value === null || input_value === '') {
+        // Convert null, undefined, '', NaN values to null:
+        // https://developer.mozilla.org/en-US/docs/Glossary/Falsy
+        if (!input_value) {
             this.inputs[input_key] = null;
             return true;
         }

--- a/src/input_data/parse_input_data.js
+++ b/src/input_data/parse_input_data.js
@@ -47,7 +47,6 @@ export class ParseInputs {
             'court_ordered_child_support_payments',
             'rent_or_mortgage',
             'homeowners_insurance_and_taxes',
-            'utility_costs',
         ];
 
         const UTILITY_ALLOWANCE_INPUT = 'utility_allowance';
@@ -126,6 +125,7 @@ export class ParseInputs {
     handle_utility_allowance_input(input_key) {
         // Check if the key exists in the inputs object
         if (!(input_key in this.inputs)) {
+            this.inputs[input_key] = 'NONE';
             return true;
         }
 

--- a/src/program_data/state_options.js
+++ b/src/program_data/state_options.js
@@ -53,6 +53,12 @@ export const STATE_OPTIONS /*: StateOptions */ = {
             'use_emergency_allotment': true,
             'uses_bbce': false,
             'website': 'https://commonhelp.virginia.gov/',
+            'standard_utility_allowances': {
+                'HEATING_AND_COOLING': {
+                    'below_four': 303,
+                    'four_or_more': 379,
+                },
+            },
             'next_steps': [
                 {
                     'url': 'https://commonhelp.virginia.gov/',

--- a/src/program_data/state_options.js
+++ b/src/program_data/state_options.js
@@ -12,7 +12,6 @@ type StateYearOption = {
 type IndividualStateOption = {
     uses_bbce: boolean;
     child_support_payments_treatment: string;
-    mandatory_standard_utility_allowances?: boolean;
     gross_income_limit_factor?: number;
     resource_limit_elderly_or_disabled?: ?number;
     resource_limit_elderly_or_disabled_income_twice_fpl?: ?number;
@@ -25,7 +24,6 @@ export const STATE_OPTIONS /*: StateOptions */ = {
         '2020': {
             'child_support_payments_treatment': 'EXCLUDE',
             'gross_income_limit_factor': 1.65,
-            'mandatory_standard_utility_allowances': true,
             'resource_limit_elderly_or_disabled': null,
             'resource_limit_elderly_or_disabled_income_twice_fpl': 3500,
             'resource_limit_non_elderly_or_disabled': null,
@@ -46,7 +44,6 @@ export const STATE_OPTIONS /*: StateOptions */ = {
     'VA': {
         '2020': {
             'child_support_payments_treatment': 'EXCLUDE', // This matches materials provided by VPLC and VA DSS but not the latest USDA State Options Report
-            'mandatory_standard_utility_allowances': false,
             'standard_medical_deduction': true,
             'standard_medical_deduction_amount': 200,
             'standard_medical_deduction_ceiling': 235,

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -65,7 +65,6 @@ export class SnapEstimate {
     standard_medical_deduction_amount: number;
     standard_medical_deduction_ceiling: number;
     standard_utility_allowances: Object;
-    mandatory_standard_utility_allowances: boolean;
     state_website: string;
 
     // Calculated
@@ -121,7 +120,6 @@ export class SnapEstimate {
         this.standard_medical_deduction = state_options['standard_medical_deduction'];
         this.standard_medical_deduction_amount = state_options['standard_medical_deduction_amount'];
         this.standard_medical_deduction_ceiling = state_options['standard_medical_deduction_ceiling'];
-        this.mandatory_standard_utility_allowances = state_options['mandatory_standard_utility_allowances'];
         this.standard_utility_allowances = state_options['standard_utility_allowances'];
         this.state_website = state_options['website'];
 
@@ -233,7 +231,6 @@ export class SnapEstimate {
             'homeowners_insurance_and_taxes': this.homeowners_insurance_and_taxes,
             'utility_costs': this.utility_costs,
             'utility_allowance': this.utility_allowance,
-            'mandatory_standard_utility_allowances': this.mandatory_standard_utility_allowances,
             'standard_utility_allowances': this.standard_utility_allowances,
             'child_support_payments_treatment': this.child_support_payments_treatment,
             'court_ordered_child_support_payments': this.court_ordered_child_support_payments,

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -29,7 +29,6 @@ interface SnapEstimateInputs {
     rent_or_mortgage?: ?number;
     homeowners_insurance_and_taxes?: ?number;
     utility_allowance?: ?string;
-    utility_costs?: ?number;
     court_ordered_child_support_payments?: ?number;
     use_emergency_allotment: boolean;
 }
@@ -51,7 +50,6 @@ export class SnapEstimate {
     rent_or_mortgage: ?number;
     homeowners_insurance_and_taxes: ?number;
     utility_allowance: ?string;
-    utility_costs: ?number;
 
     // State Options
     state_options: Object;
@@ -94,7 +92,6 @@ export class SnapEstimate {
         this.use_emergency_allotment = inputs.use_emergency_allotment;
         this.rent_or_mortgage = inputs.rent_or_mortgage;
         this.homeowners_insurance_and_taxes = inputs.homeowners_insurance_and_taxes;
-        this.utility_costs = inputs.utility_costs;
         this.utility_allowance = inputs.utility_allowance;
 
         const state_options = STATE_OPTIONS[this.state_or_territory][2020];
@@ -229,7 +226,6 @@ export class SnapEstimate {
             'standard_medical_deduction_ceiling': this.standard_medical_deduction_ceiling,
             'rent_or_mortgage': this.rent_or_mortgage,
             'homeowners_insurance_and_taxes': this.homeowners_insurance_and_taxes,
-            'utility_costs': this.utility_costs,
             'utility_allowance': this.utility_allowance,
             'standard_utility_allowances': this.standard_utility_allowances,
             'child_support_payments_treatment': this.child_support_payments_treatment,

--- a/src/snap_estimate_entrypoint.js
+++ b/src/snap_estimate_entrypoint.js
@@ -16,7 +16,6 @@ interface SnapEntrypointInputs {
     rent_or_mortgage?: ?number;
     homeowners_insurance_and_taxes?: ?number;
     utility_allowance?: ?string;
-    utility_costs?: ?number;
     court_ordered_child_support_payments?: ?number;
     use_emergency_allotment: boolean;
 }

--- a/test/parse_inputs_test.js
+++ b/test/parse_inputs_test.js
@@ -43,7 +43,7 @@ describe('ParseInputs', () => {
             'rent_or_mortgage': 0,
             'resources': 0,
             'state_or_territory': 'IL',
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 
@@ -72,7 +72,7 @@ describe('ParseInputs', () => {
             'rent_or_mortgage': 0,
             'resources': 1001,
             'state_or_territory': 'IL',
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 
@@ -102,7 +102,7 @@ describe('ParseInputs', () => {
             'rent_or_mortgage': 0,
             'resources': 1001,
             'state_or_territory': 'IL',
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 
@@ -132,7 +132,7 @@ describe('ParseInputs', () => {
             'rent_or_mortgage': 0,
             'resources': 1001,
             'state_or_territory': 'IL',
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 
@@ -161,7 +161,7 @@ describe('ParseInputs', () => {
             'rent_or_mortgage': 0,
             'resources': 0,
             'state_or_territory': 'IL',
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 
@@ -262,7 +262,7 @@ describe('ParseInputs', () => {
             'homeowners_insurance_and_taxes': 0,
             'medical_expenses_for_elderly_or_disabled': 0,
             'rent_or_mortgage': 0,
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 
@@ -293,7 +293,7 @@ describe('ParseInputs', () => {
             'homeowners_insurance_and_taxes': 0,
             'medical_expenses_for_elderly_or_disabled': 0,
             'rent_or_mortgage': 0,
-            'utility_costs': 0,
+            'utility_allowance': 'NONE',
         });
     });
 });

--- a/test/parse_inputs_test.js
+++ b/test/parse_inputs_test.js
@@ -216,8 +216,7 @@ describe('ParseInputs', () => {
         assert.equal(parser.inputs_valid(), true);
     });
 
-
-    it('should add an errors on invalid utility allowance value', () => {
+    it('should add an error on invalid utility allowance value', () => {
         const inputs = {
             'state_or_territory': 'IL',
             'household_includes_elderly_or_disabled': 'false',
@@ -234,6 +233,68 @@ describe('ParseInputs', () => {
         assert.deepEqual(parser.errors, [
             'Unknown standard utility allowance: 7'
         ]);
+    });
+
+    it('should convert a null utility allowance value to "NONE"', () => {
+        const inputs = {
+            'state_or_territory': 'IL',
+            'household_includes_elderly_or_disabled': 'false',
+            'monthly_non_job_income': '0',
+            'monthly_job_income': '0',
+            'household_size': '1',
+            'resources': '0',
+            'utility_allowance': null,
+        };
+
+        const parser = new ParseInputs(inputs);
+
+        assert.equal(parser.inputs_valid(), true);
+        assert.deepEqual(parser.inputs, {
+            'state_or_territory': 'IL',
+            'household_includes_elderly_or_disabled': false,
+            'monthly_non_job_income': 0,
+            'monthly_job_income': 0,
+            'household_size': 1,
+            'resources': 0,
+            'utility_allowance': 'NONE',
+            'court_ordered_child_support_payments': 0,
+            'dependent_care_costs': 0,
+            'homeowners_insurance_and_taxes': 0,
+            'medical_expenses_for_elderly_or_disabled': 0,
+            'rent_or_mortgage': 0,
+            'utility_costs': 0,
+        });
+    });
+
+    it('should convert an undefined utility allowance value to "NONE"', () => {
+        const inputs = {
+            'state_or_territory': 'IL',
+            'household_includes_elderly_or_disabled': 'false',
+            'monthly_non_job_income': '0',
+            'monthly_job_income': '0',
+            'household_size': '1',
+            'resources': '0',
+            'utility_allowance': undefined,
+        };
+
+        const parser = new ParseInputs(inputs);
+
+        assert.equal(parser.inputs_valid(), true);
+        assert.deepEqual(parser.inputs, {
+            'state_or_territory': 'IL',
+            'household_includes_elderly_or_disabled': false,
+            'monthly_non_job_income': 0,
+            'monthly_job_income': 0,
+            'household_size': 1,
+            'resources': 0,
+            'utility_allowance': 'NONE',
+            'court_ordered_child_support_payments': 0,
+            'dependent_care_costs': 0,
+            'homeowners_insurance_and_taxes': 0,
+            'medical_expenses_for_elderly_or_disabled': 0,
+            'rent_or_mortgage': 0,
+            'utility_costs': 0,
+        });
     });
 });
 


### PR DESCRIPTION
# Policy notes 

+ We heard from Legal Aid lawyers in VA that we should update our utility costs question: "Most people don’t know what they pay in utilities. Usually they just take the standard utility deduction."
  + VA SUA (standard utility allowance) amounts supplied by VPLC 

# API updates

+ This PR removes the `mandatory_standard_utility_allowances` field; my impression was that a state without mandatory standard utility allowances asked for actual utility costs, but that was not correct. In Virginia's case, standard utility allowances are allowed — and the most frequently-used option — but not mandatory. Removing this field because in practice it seems that both VA and IL use SUAs, even though they are mandatory only in IL. 
+ This PR also removes the `utility_costs` input, since neither of the two states covered by this prototype are sending raw utility costs to the API now. 

# Benefit calculator implementation PR

https://github.com/18F/snap-js-prescreener-prototypes/pull/32