### PR TITLE
(WIP) Remove state_website and next_steps from API output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This prototype SNAP API calculates a household's estimated eligibility for the S
 + an estimate of that household's SNAP eligibility
 + an estimated benefit amount
 + an explanation of the logic behind the API's decision-making
-+ a link to a state website where a household could apply for SNAP
 
 # Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-js-rules",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A SNAP eligibility calculator in JavaScript",
   "private": "true",
   "dependencies": {},

--- a/src/program_data/state_options.js
+++ b/src/program_data/state_options.js
@@ -38,7 +38,6 @@ export const STATE_OPTIONS /*: StateOptions */ = {
             },
             'use_emergency_allotment': true,
             'uses_bbce': true,
-            'website': 'https://abe.illinois.gov/abe/access/'
         }
     },
     'VA': {
@@ -49,23 +48,12 @@ export const STATE_OPTIONS /*: StateOptions */ = {
             'standard_medical_deduction_ceiling': 235,
             'use_emergency_allotment': true,
             'uses_bbce': false,
-            'website': 'https://commonhelp.virginia.gov/',
             'standard_utility_allowances': {
                 'HEATING_AND_COOLING': {
                     'below_four': 303,
                     'four_or_more': 379,
-                },
-            },
-            'next_steps': [
-                {
-                    'url': 'https://commonhelp.virginia.gov/',
-                    'name': 'Apply online using CommonHelp.',
-                },
-                {
-                    'url': 'https://www.dss.virginia.gov/localagency/index.cgi',
-                    'name': 'Apply at a local department near you.',
                 }
-            ]
+            }
         }
     }
 };

--- a/src/snap_estimate.js
+++ b/src/snap_estimate.js
@@ -63,7 +63,6 @@ export class SnapEstimate {
     standard_medical_deduction_amount: number;
     standard_medical_deduction_ceiling: number;
     standard_utility_allowances: Object;
-    state_website: string;
 
     // Calculated
     gross_income_calculation: Object;
@@ -118,7 +117,6 @@ export class SnapEstimate {
         this.standard_medical_deduction_amount = state_options['standard_medical_deduction_amount'];
         this.standard_medical_deduction_ceiling = state_options['standard_medical_deduction_ceiling'];
         this.standard_utility_allowances = state_options['standard_utility_allowances'];
-        this.state_website = state_options['website'];
 
         this.net_monthly_income_limit = new FetchIncomeLimit({
             'state_or_territory': this.state_or_territory,
@@ -173,7 +171,6 @@ export class SnapEstimate {
             'emergency_allotment_estimated_benefit': this.emergency_allotment_estimated_benefit, // If emergency allotments are in effect, a household may receive a higher benefit total. This value may be null if emergency allotments are not in effect.
             'estimated_eligibility': this.estimated_eligibility,
             'eligibility_factors': eligibility_factors,
-            'state_website': this.state_website,
         };
     }
 


### PR DESCRIPTION
# Notes 

This PR on the prescreener side — https://github.com/18F/snap-js-prescreener-prototypes/pull/36 — moves per-state data about next steps for applying to SNAP over to the prescreener, rather than reading them in from the JS API.

The API's focus is knowing about eligibility; "next step" info will likely vary widely by client and is likely best implemented on the client side.