### PR TITLE
Add eligibility factor types 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-js-rules",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A SNAP eligibility calculator in JavaScript",
   "private": "true",
   "dependencies": {},

--- a/src/amount/benefit_amount_estimate.js
+++ b/src/amount/benefit_amount_estimate.js
@@ -18,10 +18,11 @@ export class BenefitAmountEstimate {
     calculate() {
         if (!this.is_eligible) {
             return {
-                'name': 'Estimated Benefit Calculation',
+                'name': 'Benefit Amount',
                 'result': 0,
                 'explanation': ['Likely not eligible for SNAP.'],
-                'sort_order': 5
+                'sort_order': 5,
+                'type': 'amount',
             };
         }
 
@@ -87,6 +88,7 @@ export class BenefitAmountEstimate {
                 'sort_order': 5,
                 'result': estimated_benefit,
                 'explanation': explanation,
+                'type': 'amount',
             };
         }
 

--- a/src/amount/benefit_amount_estimate.js
+++ b/src/amount/benefit_amount_estimate.js
@@ -108,6 +108,7 @@ export class BenefitAmountEstimate {
             'result': estimated_benefit,
             'emergency_allotment_estimated_benefit': max_allotment,
             'explanation': explanation,
+            'type': 'amount'
         };
     }
 }

--- a/src/income/gross_income.js
+++ b/src/income/gross_income.js
@@ -48,7 +48,8 @@ export class GrossIncome {
             'name': 'Gross Income',
             'result': monthly_income_minus_child_support,
             'explanation': explanation,
-            'sort_order': 0
+            'sort_order': 0,
+            'type': 'income',
         };
     }
 

--- a/src/income/gross_income.js
+++ b/src/income/gross_income.js
@@ -73,7 +73,8 @@ export class GrossIncome {
             'name': 'Gross Income',
             'result': monthly_income,
             'explanation': explanation,
-            'sort_order': 0
+            'sort_order': 0,
+            'type': 'income',
         };
     }
 }

--- a/src/income/net_income.js
+++ b/src/income/net_income.js
@@ -38,6 +38,7 @@ export class NetIncome {
                 'result': 0,
                 'explanation': ['Since the household does not have income, net income is zero.'],
                 'sort_order': 1,
+                'type': 'income',
             };
         }
 

--- a/src/income/net_income.js
+++ b/src/income/net_income.js
@@ -138,6 +138,7 @@ export class NetIncome {
             'result': result,
             'explanation': explanation,
             'sort_order': 1,
+            'type': 'income',
         };
     }
 }

--- a/src/tests/asset_test.js
+++ b/src/tests/asset_test.js
@@ -46,6 +46,7 @@ export class AssetTest {
             'result': below_resource_limit,
             'explanation': explanation,
             'sort_order': 4,
+            'type': 'test'
         };
     }
 }

--- a/src/tests/asset_test.js
+++ b/src/tests/asset_test.js
@@ -18,6 +18,7 @@ export class AssetTest {
                     `${this.state_or_territory} does not have an asset test for SNAP eligibility.`
                 ],
                 'sort_order': 4,
+                'type': 'test'
             };
         }
 

--- a/src/tests/gross_income_test.js
+++ b/src/tests/gross_income_test.js
@@ -52,6 +52,7 @@ class GrossIncomeTest {
             'result': below_gross_income_limit,
             'explanation': explanation,
             'sort_order': 2,
+            'type': 'test'
         };
     }
 }

--- a/src/tests/gross_income_test.js
+++ b/src/tests/gross_income_test.js
@@ -24,6 +24,7 @@ class GrossIncomeTest {
                     'Households with an elderly or disabled member do not need to meet the gross income test.'
                 ],
                 'sort_order': 2,
+                'type': 'test',
             };
         }
 

--- a/src/tests/net_income_test.js
+++ b/src/tests/net_income_test.js
@@ -34,6 +34,7 @@ export class NetIncomeTest {
             'result': below_net_income_limit,
             'explanation': explanation,
             'sort_order': 3,
+            'type': 'test'
         };
     }
 }

--- a/src/tests/net_income_test.js
+++ b/src/tests/net_income_test.js
@@ -25,7 +25,7 @@ export class NetIncomeTest {
             : 'does not meet';
 
         const result_explanation = (
-            `Since the household net income is $${this.net_income}, this household <strong>${result_in_words}</strong> the net income test.`
+            `Since the household net income (gross income minus deductions for expenses) is $${this.net_income}, this household <strong>${result_in_words}</strong> the net income test.`
         );
         explanation.push(result_explanation);
 


### PR DESCRIPTION
# Notes 

+ Send down "type" data with each eligibility factor to distinguish between:

1. Eligibility tests
2. Income logic (net income calculation, gross income calculation)
3. Benefit amount logic

This enables more thoughtful and responsive presentation of eligibility logic on the client side. 

# Prescreener / calculator PR 

+ https://github.com/18F/snap-js-prescreener-prototypes/pull/37