### PR TITLE
Remove "why" links from explanation output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-js-rules",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-js-rules",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A SNAP eligibility calculator in JavaScript",
   "private": "true",
   "dependencies": {},

--- a/src/amount/benefit_amount_estimate.js
+++ b/src/amount/benefit_amount_estimate.js
@@ -38,9 +38,7 @@ export class BenefitAmountEstimate {
             'household_size': this.household_size,
         }).calculate();
 
-        const max_allotment_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Maximum-Allotments-Deductions.pdf';
-        const max_allotment_explanation = `The maximum allotment for this household is $${max_allotment}. <a class='why why-small' href='${max_allotment_pdf_url}' target='_blank'>why?</a>`;
-
+        const max_allotment_explanation = `The maximum allotment for this household is $${max_allotment}.`;
         explanation.push(max_allotment_explanation);
 
         const thirty_percent_net_income = Math.round(this.net_income * 0.3);
@@ -62,8 +60,7 @@ export class BenefitAmountEstimate {
         if (min_allotment && min_allotment > estimated_benefit) {
             estimated_benefit = min_allotment;
 
-            const min_allotment_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Minimum-Allotments.pdf';
-            const min_allotment_explanation = `There is a minimum monthly allotmnet for this household of $${min_allotment}. <a class='why why-small' href='${min_allotment_pdf_url}' target='_blank'>why?</a>`;
+            const min_allotment_explanation = `There is a minimum monthly allotmnet for this household of $${min_allotment}.`;
             explanation.push(min_allotment_explanation);
             const min_allotment_applied_explanation = (
                 `Since the calculated benefit amount would be below the minimum allotment, apply the minimum allotment amount of $${min_allotment} instead.`

--- a/src/deductions/standard_deduction.js
+++ b/src/deductions/standard_deduction.js
@@ -14,10 +14,8 @@ export class StandardDeduction {
 
         const result = deductions_api.calculate();
 
-        const standard_deduction_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Maximum-Allotments-Deductions.pdf';
-
         const explanation = [
-            `Next, we need to take into account deductions. We start with a standard deduction of $${result}. <a class='why why-small' href='${standard_deduction_pdf_url}' target='_blank'>why?</a>`
+            `Next, we need to take into account deductions. We start with a standard deduction of $${result}.`
         ];
 
         return {

--- a/src/tests/gross_income_test.js
+++ b/src/tests/gross_income_test.js
@@ -36,9 +36,7 @@ class GrossIncomeTest {
             this.gross_monthly_income_limit > this.gross_income
         );
 
-        const income_limits_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Income-Eligibility-Standards.pdf';
-        const gross_monthly_income_limit_explanation = `The gross monthly income limit is $${this.gross_monthly_income_limit}. <a class='why why-small' href='${income_limits_pdf_url}' target='_blank'>why?</a>`;
-
+        const gross_monthly_income_limit_explanation = `The gross monthly income limit is $${this.gross_monthly_income_limit}.`;
         explanation.push(gross_monthly_income_limit_explanation);
 
         const result_in_words = (below_gross_income_limit)

--- a/src/tests/net_income_test.js
+++ b/src/tests/net_income_test.js
@@ -14,9 +14,8 @@ export class NetIncomeTest {
         );
         explanation.push(explanation_intro);
 
-        const income_limits_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Income-Eligibility-Standards.pdf';
         const net_monthly_income_limit_explanation = (
-            `The net monthly income limit is $${this.net_monthly_income_limit}. <a class='why why-small' href='${income_limits_pdf_url}' target='_blank'>why?</a>`
+            `The net monthly income limit is $${this.net_monthly_income_limit}.`
         );
         explanation.push(net_monthly_income_limit_explanation);
 


### PR DESCRIPTION
# Notes 

+ Usability testing showed these PDF links were difficult for users to read and interpret
+ It's probably better not to return `<a>` tags in our results anyway